### PR TITLE
Adding a Custom Title Bar Toggle to the General Settings

### DIFF
--- a/src/jvmMain/kotlin/Main.kt
+++ b/src/jvmMain/kotlin/Main.kt
@@ -1,3 +1,5 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import commands.CommandRegistry
@@ -9,28 +11,47 @@ import ui.views.MainView
 import utils.WindowHandler
 
 @OptIn(DelicateCoroutinesApi::class)
+@Composable
+private fun WindowContent(scope: FrameWindowScope, content: @Composable () -> Unit) {
+    WindowHandler.windowContent(scope) {
+        content()
+    }
+
+    GlobalScope.launch {
+        while (true) {
+            MobileDeviceRepository.fetchConnectedDevices()
+
+            delay(100)
+        }
+    }
+}
+
+@OptIn(DelicateCoroutinesApi::class)
 fun main(args: Array<String>) = application {
     GlobalSettings.loadGlobalSettings()
 
     CommandRegistry().executeCommand(args.toList())
 
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "Toolcat",
-        undecorated = WindowHandler.useCustomDecoration(),
-        transparent = WindowHandler.useCustomDecoration()
-    ) {
-        WindowHandler.windowContent(this) {
-            ToolcatTheme.runCompose {
-                MainView()
+    if (GlobalSettings.customTitleBar.value) {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Toolcat",
+            undecorated = WindowHandler.useCustomDecoration(),
+            transparent = WindowHandler.useCustomDecoration()
+        ) {
+            WindowContent(this) {
+                ToolcatTheme.runCompose {
+                    MainView()
+                }
             }
         }
-
-        GlobalScope.launch {
-            while (true) {
-                MobileDeviceRepository.fetchConnectedDevices()
-
-                delay(100)
+    } else {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Toolcat",
+        ) {
+            WindowContent(this) {
+                MainView()
             }
         }
     }

--- a/src/jvmMain/kotlin/settings/GlobalSettings.kt
+++ b/src/jvmMain/kotlin/settings/GlobalSettings.kt
@@ -9,11 +9,13 @@ object GlobalSettings {
     var iosSimulatorSupportEnabled: Boolean = false
     var enableDarkMode: MutableState<Boolean> = mutableStateOf(false)
     var selectedTheme: MutableState<Int> = mutableStateOf(0)
+    var customTitleBar: MutableState<Boolean> = mutableStateOf(false)
 
     fun saveGlobalSettings() {
         Preferences.userRoot().putBoolean("ios-support", iosSupportEnabled)
         Preferences.userRoot().putBoolean("ios-simulator-support", iosSimulatorSupportEnabled)
         Preferences.userRoot().putBoolean("dark-theme", enableDarkMode.value)
+        Preferences.userRoot().putBoolean("custom-title-bar", customTitleBar.value)
         Preferences.userRoot().putInt("selected-theme", selectedTheme.value)
     }
 
@@ -21,6 +23,7 @@ object GlobalSettings {
         iosSupportEnabled = Preferences.userRoot().getBoolean("ios-support", iosSupportEnabled)
         iosSimulatorSupportEnabled = Preferences.userRoot().getBoolean("ios-simulator-support", iosSimulatorSupportEnabled)
         enableDarkMode.value = Preferences.userRoot().getBoolean("dark-theme", enableDarkMode.value)
+        customTitleBar.value = Preferences.userRoot().getBoolean("custom-title-bar", customTitleBar.value)
         selectedTheme.value = Preferences.userRoot().getInt("selected-theme", selectedTheme.value)
     }
 }

--- a/src/jvmMain/kotlin/settings/SettingsClusterCollection.kt
+++ b/src/jvmMain/kotlin/settings/SettingsClusterCollection.kt
@@ -3,12 +3,12 @@ package settings
 import settings.views.*
 
 val settingsClusterList: Array<SettingsCluster> = arrayOf(
-    /*SettingsCluster(
+    SettingsCluster(
         title = "General",
         settings = arrayOf(
-            CheckForUpdatesSettingsModel()
+            CustomWindowTitleBarModel()
         )
-    ),*/
+    ),
     SettingsCluster(
         title = "Apple Devices",
         settings = arrayOf(

--- a/src/jvmMain/kotlin/settings/views/CustomWindowTitleBarModel.kt
+++ b/src/jvmMain/kotlin/settings/views/CustomWindowTitleBarModel.kt
@@ -1,0 +1,56 @@
+package settings.views
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import settings.GlobalSettings
+import settings.SettingsViewModel
+
+class CustomWindowTitleBarModel : SettingsViewModel {
+    @Composable
+    override fun content() {
+        val checked by remember { mutableStateOf(GlobalSettings.customTitleBar) }
+
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .height(40.dp),
+
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Text(
+                    text = "Enable the Custom Title Bar",
+                    fontSize = 18.sp,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+
+            Switch(
+                checked = checked.value,
+                onCheckedChange = {
+                    checked.value = it
+
+                    GlobalSettings.customTitleBar = checked
+                    GlobalSettings.saveGlobalSettings()
+                }
+            )
+        }
+    }
+}

--- a/src/jvmMain/kotlin/utils/WindowHandler.kt
+++ b/src/jvmMain/kotlin/utils/WindowHandler.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.FrameWindowScope
+import settings.GlobalSettings
 import ui.window.MacOSTitleBar
 import ui.window.WindowsTitleBar
 import java.util.*
@@ -26,7 +27,7 @@ object WindowHandler {
 
     @Composable
     fun windowContent(window: FrameWindowScope, content: @Composable () -> Unit) {
-        if (useCustomDecoration()) {
+        if (useCustomDecoration() && GlobalSettings.customTitleBar.value) {
             val os = System.getProperty("os.name").lowercase(Locale.getDefault())
             val isMacOS = os.contains("mac os x")
 


### PR DESCRIPTION
# Custom Title Bar Toggle

The custom Title Bar had a lot of issues. For example:
- No window maximization 
- No hot corners for window layouting _(a Compose Desktop issue?)_
- No fullscreen mode for MacOS
- No native windowing features
-  ...

## The Solution?

First of all, this PR makes the Custom Title Bar toggable. It is off by default.

A new Custom Title Bar with all those issues resolved will be added with `Hofmeister Kit` which will be added with [this Issue](#5), and will probably be available in **Version 1.1.0** (no promises)
